### PR TITLE
style(runtime): set aria-hidden to true to the splite for the accessi…

### DIFF
--- a/runtime/browser-sprite.js
+++ b/runtime/browser-sprite.js
@@ -11,7 +11,12 @@ let sprite;
 if (isSpriteExists) {
   sprite = window[spriteGlobalVarName];
 } else {
-  sprite = new BrowserSprite({ attrs: { id: spriteNodeId } });
+  sprite = new BrowserSprite({
+    attrs: {
+      id: spriteNodeId,
+      'aria-hidden': 'true'
+    }
+  });
   window[spriteGlobalVarName] = sprite;
 }
 


### PR DESCRIPTION
…bility reason

The sprite is inserted immediately below the body element, but all elements immediately below the
body must be either landmarks or invisible for the blind users. Please see this document for the
detail. https://dequeuniversity.com/rules/axe/3.2/region?application=axeAPI

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

improve accessibility

**What is the current behavior? (You can also link to an open issue here)**

The splite is inserted immediately below the body element and is not marked as `aria-hidden`  so that blind people's experience goes bad and some accessibility tools [(react-axe)](https://github.com/dequelabs/react-axe) cause a warning like below.

![image](https://user-images.githubusercontent.com/1257695/59488040-65d40b00-8eb9-11e9-998a-ea8a98eb2e33.png)

**What is the new behavior (if this is a feature change)?**

Set `aria-hidden=true` to the splite

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills [contributing guidelines](https://github.com/kisenka/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**

Linted, tested and followed the rules of commits 😺 
