### PR TITLE
Fix for environments without webpack (linting)

### DIFF
--- a/lib/utils/get-webpack-version.js
+++ b/lib/utils/get-webpack-version.js
@@ -6,7 +6,7 @@ if (!require.main || !require.main.require) {
 let webpackVersion = '';
 try {
   webpackVersion = require.main.require('webpack/package.json').version;
-} catch (err) { /* ignore */}
+} catch (err) { /* ignore */ }
 
 /**
  * @param {boolean} [onlyMajor=true]

--- a/lib/utils/get-webpack-version.js
+++ b/lib/utils/get-webpack-version.js
@@ -1,9 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 // require.main is undefined while running WebStorm code assistance analyzer of webpack.config.js
-if (!require.main) {
+if (!require.main || !require.main.require) {
   require.main = { require };
 }
-const webpackVersion = require.main.require('webpack/package.json').version;
+let webpackVersion = '';
+try {
+  webpackVersion = require.main.require('webpack/package.json').version;
+} catch (err) { /* ignore */}
 
 /**
  * @param {boolean} [onlyMajor=true]


### PR DESCRIPTION
This allows linters, which are not using webpack, to not explode at this dependency line.

There are other ways this could be addressed, but this is one that works for me.

It also includes the require.main.require check from #382 for phpstorm environments.