### PR TITLE
feat(outputPath): add possibility to define output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Webpack loader for creating SVG sprites.
     - [`extract`](#extract)
     - [`spriteFilename`](#sprite-filename)
     - [`publicPath`](#public-path)
+    - [`outputPath`](#output-path)
     - [`plainSprite`](#plain-sprite)
     - [`spriteAttrs`](#sprite-attrs)
 - [Examples](#examples)
@@ -237,6 +238,25 @@ Custom public path for sprite file.
   options: {
     extract: true,
     publicPath: '/'
+  }
+}
+```
+
+<a id="output-path"></a>
+### `outputPath` (type: `string`, default: null`)
+
+Custom output path for sprite file.
+By default it will use `publicPath`.
+This param is useful if you want to store sprite is a directory with a custom http access.
+
+```js
+{
+  test: /\.svg$/,
+  loader: 'svg-sprite-loader',
+  options: {
+    extract: true,
+    outputPath: 'custom-dir/sprites/'
+    publicPath: 'sprites/'
   }
 }
 ```

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -63,6 +63,11 @@ class SVGSpritePlugin {
   apply(compiler) {
     this.rules = getMatchedRule(compiler);
 
+    const path = this.rules.outputPath ? this.rules.outputPath : this.rules.publicPath;
+    this.filenamePrefix = path
+      ? path.replace(/^\//, '')
+      : '';
+
     if (compiler.hooks) {
       compiler.hooks
         .thisCompilation
@@ -162,11 +167,8 @@ class SVGSpritePlugin {
       })
         .then((sprite) => {
           const content = sprite.render();
-          const filenamePrefix = this.rules.publicPath
-            ? this.rules.publicPath.replace(/^\//, '')
-            : '';
 
-          compilation.assets[`${filenamePrefix}${filename}`] = {
+          compilation.assets[`${this.filenamePrefix}${filename}`] = {
             source() { return content; },
             size() { return content.length; }
           };
@@ -209,11 +211,9 @@ class SVGSpritePlugin {
 
   beforeHtmlGeneration(compilation) {
     const itemsBySprite = this.map.groupItemsBySpriteFilename();
-    const filenamePrefix = this.rules.publicPath
-            ? this.rules.publicPath.replace(/^\//, '')
-            : '';
+
     const sprites = Object.keys(itemsBySprite).reduce((acc, filename) => {
-      acc[filenamePrefix + filename] = compilation.assets[filenamePrefix + filename].source();
+      acc[this.filenamePrefix + filename] = compilation.assets[this.filenamePrefix + filename].source();
       return acc;
     }, {});
 

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -446,6 +446,28 @@ describe('loader and plugin', () => {
       assets['main.js'].source().should.contain(`__webpack_require__.p + "${spriteFilename}`);
     });
 
+    it('should generate asset with output path without changing publicPath', async () => {
+      const publicPath = '/olala/';
+      const spriteFilename = defaultSpriteFilename;
+
+      const v4Config = {};
+      if (webpackVersion.IS_4) {
+        v4Config.mode = 'development';
+        v4Config.devtool = false;
+      }
+
+      const { assets } = await compile(Object.assign(v4Config, {
+        entry: './entry',
+        output: { publicPath },
+        module: rules(
+          svgRule({ extract: true, spriteFilename, outputPath: '/foo/' })
+        ),
+        plugins: [new SpritePlugin()]
+      }));
+
+      assets['main.js'].source().should.contain(`__webpack_require__.p + "${spriteFilename}`);
+    });
+
     it('should emit only built chunks', () => {
       // TODO test with webpack-recompilation-emulator
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

- Add possibility to define output path.
- Add documentation

**What is the current behavior? (You can also link to an open issue here)**

We could only define a public path (ie: Browser path to get the generated file)

**What is the new behavior (if this is a feature change)?**

- Be able to store sprite in a different path from it's accessible path
With webpack, concepts of *outputPath* and *publicPath* are different.
This allows you to have on the server side a different file structure than the access url. This can be very useful when our server rewrites the urls on the fly.

Many loader allow to manage this feature, that's why I suggest it.
**Does this PR introduce a breaking change?**

Nope, made it retrocompatible because this `param` is not required.

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
