### PR TITLE
fix: Remove require override

### DIFF
--- a/lib/utils/get-webpack-version.js
+++ b/lib/utils/get-webpack-version.js
@@ -1,16 +1,17 @@
-const webpackVersion = require("webpack/package.json").version;
+// eslint-disable-next-line import/no-extraneous-dependencies
+const webpackVersion = require('webpack/package.json').version;
 
 /**
  * @param {boolean} [onlyMajor=true]
  * @return {string}
  */
 function getWebpackVersion(onlyMajor = true) {
-  return onlyMajor ? webpackVersion.split(".")[0] : webpackVersion;
+  return onlyMajor ? webpackVersion.split('.')[0] : webpackVersion;
 }
 
-getWebpackVersion.IS_1 = getWebpackVersion() === "1";
-getWebpackVersion.IS_2 = getWebpackVersion() === "2";
-getWebpackVersion.IS_3 = getWebpackVersion() === "3";
-getWebpackVersion.IS_4 = getWebpackVersion() === "4";
+getWebpackVersion.IS_1 = getWebpackVersion() === '1';
+getWebpackVersion.IS_2 = getWebpackVersion() === '2';
+getWebpackVersion.IS_3 = getWebpackVersion() === '3';
+getWebpackVersion.IS_4 = getWebpackVersion() === '4';
 
 module.exports = getWebpackVersion;

--- a/lib/utils/get-webpack-version.js
+++ b/lib/utils/get-webpack-version.js
@@ -1,21 +1,16 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-// require.main is undefined while running WebStorm code assistance analyzer of webpack.config.js
-if (!require.main) {
-  require.main = { require };
-}
-const webpackVersion = require.main.require('webpack/package.json').version;
+const webpackVersion = require("webpack/package.json").version;
 
 /**
  * @param {boolean} [onlyMajor=true]
  * @return {string}
  */
 function getWebpackVersion(onlyMajor = true) {
-  return onlyMajor ? webpackVersion.split('.')[0] : webpackVersion;
+  return onlyMajor ? webpackVersion.split(".")[0] : webpackVersion;
 }
 
-getWebpackVersion.IS_1 = getWebpackVersion() === '1';
-getWebpackVersion.IS_2 = getWebpackVersion() === '2';
-getWebpackVersion.IS_3 = getWebpackVersion() === '3';
-getWebpackVersion.IS_4 = getWebpackVersion() === '4';
+getWebpackVersion.IS_1 = getWebpackVersion() === "1";
+getWebpackVersion.IS_2 = getWebpackVersion() === "2";
+getWebpackVersion.IS_3 = getWebpackVersion() === "3";
+getWebpackVersion.IS_4 = getWebpackVersion() === "4";
 
 module.exports = getWebpackVersion;


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

bugfix

**What is the current behavior? (You can also link to an open issue here)**

Hello! Gatsby core team maintainer here 🙂 

The plugin breaks when used with [gatsby](http://gatsbyjs.org/) and gatsby-[plugin-svg-sprite-loader](https://github.com/stldo/gatsby-plugin-svg-sprite-loader)

To be clear, this works fine when `gatsby-cli` is run from the site modules (./node_modules/.bin/gatsby) and does _not_ when a globally installed `gatsby-cli` is run. I did some digging and this is because `require.main` (which is what is used before this PR) is an instance of Module with paths set relative to the globally installed binary versus (correctly) being relative to the site's folder (where webpack is indeed installed)

I wasn't sure _why_ this was added and wanted to open this and discuss this!

**What is the new behavior (if this is a feature change)?**

This seems to be resolved with this change

**Does this PR introduce a breaking change?**

No 

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
