### PR TITLE
support node-webkit

### DIFF
--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -6,7 +6,7 @@ const loaderDefaults = defaults.loader;
 const isomorphicSpriteModule = require.resolve('../runtime/sprite.build');
 const isomorphicSymbolModule = require.resolve('svg-baker-runtime/symbol');
 
-const isTargetBrowser = target => target === 'web' || target === 'electron-renderer' || 'node-webkit' || 'nwjs';
+const isTargetBrowser = target => target === 'web' || target === 'electron-renderer' || target === 'node-webkit' || target === 'nwjs';
 
 /**
  * @param {Object} params

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -6,7 +6,8 @@ const loaderDefaults = defaults.loader;
 const isomorphicSpriteModule = require.resolve('../runtime/sprite.build');
 const isomorphicSymbolModule = require.resolve('svg-baker-runtime/symbol');
 
-const isTargetBrowser = target => target === 'web' || target === 'electron-renderer';
+const isTargetBrowser = target => target === 'web' || target === 'electron-renderer'||'node-webkit'
+||'nwjs';
 
 /**
  * @param {Object} params

--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -6,8 +6,7 @@ const loaderDefaults = defaults.loader;
 const isomorphicSpriteModule = require.resolve('../runtime/sprite.build');
 const isomorphicSymbolModule = require.resolve('svg-baker-runtime/symbol');
 
-const isTargetBrowser = target => target === 'web' || target === 'electron-renderer'||'node-webkit'
-||'nwjs';
+const isTargetBrowser = target => target === 'web' || target === 'electron-renderer' || 'node-webkit' || 'nwjs';
 
 /**
  * @param {Object} params


### PR DESCRIPTION
Do you want to request a feature, report a bug or ask a question?
report a bug .
What is the current behavior?
when use nw,it not works. it does not inject svg to html auto.
What is the expected behavior?
wish to support when webpack's target is 'node-webkit' for nw.js and inject svg to html.
If the current behavior is a bug, please provide the steps to reproduce, at least part of webpack config with loader configuration and piece of your code.
The best way is to create repo with minimal setup to demonstrate a problem (package.json, webpack config and your code).
It you don't want to create a repository - create a gist with multiple files

If this is a feature request, what is motivation or use case for changing the behavior?
svg-sprite-loader-master\lib\configurator.js,
const isTargetBrowser = target => target === 'web' || target === 'electron-renderer';
Please tell us about your environment:

Node.js version: ?
node 12
webpack version: ?
4.41.1
svg-sprite-loader version: ?
4.3
OS type & version: ?
win 10
Other information (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)