### PR TITLE
Fix DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET

### DIFF
--- a/lib/utils/get-all-modules.js
+++ b/lib/utils/get-all-modules.js
@@ -12,7 +12,7 @@ try {
  * @return {NormalModule[]}
  */
 function getAllModules(compilation) {
-  let modules = compilation.modules;
+  let modules = Array.from(compilation.modules);
 
   // Look up in child compilations
   if (compilation.children.length > 0) {


### PR DESCRIPTION
Convert Set to array before concat/filter.

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

Handle deprecation.

Fix #430 

**What is the current behavior? (You can also link to an open issue here)**

#430 

**What is the new behavior (if this is a feature change)?**

#430 

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
