### PR TITLE
fix(additional-assets): adds missing method

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -168,7 +168,8 @@ class SVGSpritePlugin {
 
           compilation.assets[`${this.filenamePrefix}${filename}`] = {
             source() { return content; },
-            size() { return content.length; }
+            size() { return content.length; },
+            updateHash(bulkUpdateDecorator) { bulkUpdateDecorator.update(content); }
           };
         });
     });


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

bugfix

**What is the current behavior? (You can also link to an open issue here)**

When using the plugin with `extract: true` config option along `compression-webpack-plugin`, `webpack.cache.PackFileCacheStrategy` crashes.

**What is the new behavior (if this is a feature change)?**

Defining this method fixes the issue with my current build configuration.

Found the expected asset structure here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack/index.d.ts#L924

**Does this PR introduce a breaking change?**

No, it doesn't

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**

✅ 
