### PR TITLE
fix(utils): fix 'Properties descriptionData are unknown' with webpack5

### DIFF
--- a/lib/utils/get-matched-rule-5.js
+++ b/lib/utils/get-matched-rule-5.js
@@ -5,6 +5,7 @@
 const BasicEffectRulePlugin = require('webpack/lib/rules/BasicEffectRulePlugin');
 const BasicMatcherRulePlugin = require('webpack/lib/rules/BasicMatcherRulePlugin');
 const RuleSetCompiler = require('webpack/lib/rules/RuleSetCompiler');
+const DescriptionDataMatcherRulePlugin = require('webpack/lib/rules/DescriptionDataMatcherRulePlugin');
 const UseEffectRulePlugin = require('webpack/lib/rules/UseEffectRulePlugin');
 
 const ruleSetCompiler = new RuleSetCompiler([
@@ -21,6 +22,7 @@ const ruleSetCompiler = new RuleSetCompiler([
   new BasicEffectRulePlugin('sideEffects'),
   new BasicEffectRulePlugin('parser'),
   new BasicEffectRulePlugin('resolve'),
+  new DescriptionDataMatcherRulePlugin(),
   new UseEffectRulePlugin()
 ]);
 


### PR DESCRIPTION
Webpack5 as used by GatsbyJS gets cranky when the `descriptionData` attribute from assorted rules
(like its stock JS processing) isn't consumed during a compile pass. Adding this rule plugin
resolves this issue.

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

Bugfix

**What is the current behavior? (You can also link to an open issue here)**

(e.g. in Gatsby:)

```
failed Building production JavaScript and CSS bundles - 0.362s

 ERROR #98123  WEBPACK

Generating JavaScript bundles failed

Compiling RuleSet failed: Properties descriptionData are unknown (at ruleSet[0].rules[0]: [object Object])
```

...for a ruleset like:

```
{
  test: /\.js$/i,
  descriptionData: { type: 'module' },
  resolve: { byDependency: { esm: [Object] } }
}
```

...which is valid when Webpack processes it with all its built-in rules but not when we're somewhat goofily using only parts of Webpack in `get-matched-rule-5.js`.

**What is the new behavior (if this is a feature change)?**

Everything passes.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**

Yes.