### PR TITLE
#451: Fallback to using `webpack` version instead of `package.json` version

### DIFF
--- a/lib/utils/is-webpack-1.js
+++ b/lib/utils/is-webpack-1.js
@@ -1,7 +1,8 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-const webpackPkg = require("webpack/package.json") || {};
-const webpackVersion = webpackPkg.version || require("webpack").version;
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, global-require
+const webpackPkg = require('webpack/package.json') || {};
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, global-require
+const webpackVersion = webpackPkg.version || require('webpack').version;
 
-const webpackMajorVersion = parseInt(webpackVersion.split(".")[0], 10);
+const webpackMajorVersion = parseInt(webpackVersion.split('.')[0], 10);
 
 module.exports = webpackMajorVersion === 1;

--- a/lib/utils/is-webpack-1.js
+++ b/lib/utils/is-webpack-1.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-const webpackPkg = require('webpack/package.json');
+const webpackPkg = require("webpack/package.json") || {};
+const webpackVersion = webpackPkg.version || require("webpack").version;
 
-const webpackMajorVersion = parseInt(webpackPkg.version.split('.')[0], 10);
+const webpackMajorVersion = parseInt(webpackVersion.split(".")[0], 10);
 
 module.exports = webpackMajorVersion === 1;


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
This is a bugfix for issue #451 

**What is the current behavior? (You can also link to an open issue here)**
Using `svg-sprite-loader` with Next.js version 10.1.x in combination with enabling Webpack 5 results in the following error:

```TypeError: Cannot read property 'version' of undefined```

**What is the new behavior (if this is a feature change)?**
Check if we can use the version in the `package.json` file and otherwise fallback to using the `webpack` object itself which contains a `version` property.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
I can't run the tests, nor the linter myself. When installing ESLint (which probably should be in the `devDependencies`) I got lint errors on files I didn't touch. I checked the code style myself and everything seems to match.

I'm on Windows so nor the build script nor any of the test commands worked for me.