### PR TITLE
fix(utils): Account for rule property "generator"

### DIFF
--- a/lib/utils/get-matched-rule-5.js
+++ b/lib/utils/get-matched-rule-5.js
@@ -22,6 +22,7 @@ const ruleSetCompiler = new RuleSetCompiler([
   new BasicEffectRulePlugin('sideEffects'),
   new BasicEffectRulePlugin('parser'),
   new BasicEffectRulePlugin('resolve'),
+  new BasicEffectRulePlugin('generator'),
   new DescriptionDataMatcherRulePlugin(),
   new UseEffectRulePlugin()
 ]);


### PR DESCRIPTION
In Webpack 5 a new property "generator" has been added to the rule definition, which must be accounted for in the rule set.

**What kind of change does this PR introduce?**

Bugfix (See  vuejs/vue-loader#1753)

**What is the current behavior?**

#428

**Does this PR introduce a breaking change?**

No
