### PR TITLE
fix(utils): account for rule property "mimetype"

### DIFF
--- a/lib/utils/get-matched-rule-5.js
+++ b/lib/utils/get-matched-rule-5.js
@@ -23,6 +23,7 @@ const ruleSetCompiler = new RuleSetCompiler([
   new BasicEffectRulePlugin('parser'),
   new BasicEffectRulePlugin('resolve'),
   new BasicEffectRulePlugin('generator'),
+  new BasicEffectRulePlugin('mimetype'),
   new DescriptionDataMatcherRulePlugin(),
   new UseEffectRulePlugin()
 ]);


### PR DESCRIPTION
In Webpack 5, a new property "mimetype" was added to the rule definition, which must be accounted for in the rule set.

Fixes #458.

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

Bugfix

**What is the current behavior? (You can also link to an open issue here)**

See #458.

**Does this PR introduce a breaking change?**

No.
