### PR TITLE
fix(utils): fix: some options had no effect with webpack5

### DIFF
--- a/lib/utils/get-matched-rule-5.js
+++ b/lib/utils/get-matched-rule-5.js
@@ -2,62 +2,26 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable no-restricted-syntax */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const BasicEffectRulePlugin = require('webpack/lib/rules/BasicEffectRulePlugin');
-const BasicMatcherRulePlugin = require('webpack/lib/rules/BasicMatcherRulePlugin');
-const RuleSetCompiler = require('webpack/lib/rules/RuleSetCompiler');
-const DescriptionDataMatcherRulePlugin = require('webpack/lib/rules/DescriptionDataMatcherRulePlugin');
-const UseEffectRulePlugin = require('webpack/lib/rules/UseEffectRulePlugin');
 
-const ruleSetCompiler = new RuleSetCompiler([
-  new BasicMatcherRulePlugin('test', 'resource'),
-  new BasicMatcherRulePlugin('include', 'resource'),
-  new BasicMatcherRulePlugin('exclude', 'resource', true),
-  new BasicMatcherRulePlugin('resource'),
-  new BasicMatcherRulePlugin('conditions'),
-  new BasicMatcherRulePlugin('resourceQuery'),
-  new BasicMatcherRulePlugin('realResource'),
-  new BasicMatcherRulePlugin('issuer'),
-  new BasicMatcherRulePlugin('compiler'),
-  new BasicEffectRulePlugin('type'),
-  new BasicEffectRulePlugin('sideEffects'),
-  new BasicEffectRulePlugin('parser'),
-  new BasicEffectRulePlugin('resolve'),
-  new BasicEffectRulePlugin('generator'),
-  new DescriptionDataMatcherRulePlugin(),
-  new UseEffectRulePlugin()
-]);
-
-// const RuleSet = require('webpack/lib/RuleSet');
-
-const flattenAndExtractUse = rules => rules.reduce((pre, rule) => {
-  // if ('rules' in rule || 'oneOf' in rule) {
-  //   return pre.concat(flattenAndExtractUse(rule.rules || rule.oneOf));
-  // }
-  return pre.concat(rule || []);
-}, []);
+const isSpriteLoader = (rule) => {
+  if (!Object.prototype.hasOwnProperty.call(rule, 'loader')) return false;
+  return /svg-sprite-loader/.test(rule.loader);
+};
 
 module.exports = (compiler) => {
   const rawRules = compiler.options.module.rules;
-  const rulesUse = [];
+  let spriteLoader = null;
   for (const rawRule of rawRules) {
-    const clonedRawRule = Object.assign({}, rawRule);
-    delete clonedRawRule.include;
-    const ruleSet = ruleSetCompiler.compile([{
-      rules: [clonedRawRule]
-    }]);
-    rulesUse.push(ruleSet.exec({
-      resource: '.svg'
-    }));
+    if (isSpriteLoader(rawRule)) {
+      spriteLoader = rawRule;
+    } else if (Object.prototype.hasOwnProperty.call(rawRule, 'use')) {
+      for (const subLoader of rawRule.use) {
+        if (isSpriteLoader(subLoader)) {
+          spriteLoader = subLoader;
+        }
+      }
+    }
+    if (spriteLoader !== null) break;
   }
-
-  // const {
-  //   rules
-  // } = ruleSet;
-
-  const rule = flattenAndExtractUse(rulesUse)
-    .find((item) => {
-      return /svg-sprite-loader/.test(item.value.loader);
-    }) || {};
-
-  return rule.value ? rule.value.options : {};
+  return (spriteLoader !== null && spriteLoader.options !== undefined) ? spriteLoader.options : {};
 };


### PR DESCRIPTION
ISSUES CLOSED: #446

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
`ruleSet.exec({resource: '.svg'})` is used to find `svg-sprite-loader` options object,
but this approach does not work if we define a rule with something like `test: /svg-sprites.*?\.svg/`
And sometimes we need different loaders for different svg files, like:
- svg-sprite-loader for svg icons
- file-loader for single big svg files (images)

**What is the new behavior (if this is a feature change)?**
Will scan all raw rules one by one until it will find `svg-sprite-loader`, then it will break out of for-loop and will return option object for that rule.
If there is multiple rules (for some reason) it will return option object for the first one, like in the current solution.

**Does this PR introduce a breaking change?**
No
