### PR TITLE
fix(loader): Test webpack version in get-matched-rule

### DIFF
--- a/lib/utils/get-matched-rule.js
+++ b/lib/utils/get-matched-rule.js
@@ -1,11 +1,15 @@
 /* eslint-disable global-require */
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+const webpackPkg = require('webpack/package.json');
+
+const webpackMajorVer = Number((/^\d+/).exec(webpackPkg.version));
 
 let getMatchedRule = null;
 
-try {
-  getMatchedRule = require('./get-matched-rule-4');
-} catch (e) {
+if (webpackMajorVer >= 5) {
   getMatchedRule = require('./get-matched-rule-5');
+} else {
+  getMatchedRule = require('./get-matched-rule-4');
 }
 
 module.exports = getMatchedRule;


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
#461 

**What is the new behavior (if this is a feature change)?**
Checks webpack version in `get-matched-rule` to ensure we're targeting the correct webpack version.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
