### PR TITLE
fix(utils): force get-matched-rule-4 to use nearest webpack installation

### DIFF
--- a/lib/utils/get-matched-rule-4.js
+++ b/lib/utils/get-matched-rule-4.js
@@ -1,4 +1,13 @@
 /* eslint-disable import/no-unresolved */
+const path = require('path');
+
+const ruleSetDir = path.dirname(require.resolve('webpack/lib/RuleSet'));
+const webpackDir = path.dirname(require.resolve('webpack'));
+
+if (ruleSetDir !== webpackDir) {
+  throw new Error('RuleSet not found in local webpack installation');
+}
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 const RuleSet = require('webpack/lib/RuleSet');
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
#461 

**What is the new behavior (if this is a feature change)?**
The `get-matched-rule-4` util will now load `webpack/lib/RuleSet` only from the nearest `webpack` installation, it will no longer look up the chain for additional `webpack` installations until it finds the `RuleSet` file.

This eliminates the issue raised in #461, where the wrong version of `webpack` is loaded in a scenario where multiple nested `webpack` installations exist.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
