### PR TITLE
Fix #464 - rawRule.use is not iterable

### DIFF
--- a/lib/utils/get-matched-rule-5.js
+++ b/lib/utils/get-matched-rule-5.js
@@ -15,7 +15,10 @@ module.exports = (compiler) => {
     if (isSpriteLoader(rawRule)) {
       spriteLoader = rawRule;
     } else if (Object.prototype.hasOwnProperty.call(rawRule, 'use')) {
-      for (const subLoader of rawRule.use) {
+      const rawRuleUse = Array.isArray(rawRule.use)
+        ? rawRule.use
+        : [rawRule.use];
+      for (const subLoader of rawRuleUse) {
         if (isSpriteLoader(subLoader)) {
           spriteLoader = subLoader;
         }


### PR DESCRIPTION
- [fixed] TypeError: rawRule.use is not iterable

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
#464 

**What is the new behavior (if this is a feature change)?**
Added `isArray` checking and wrapping `rule.use` to array if it is an object.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
