### PR TITLE
fix: correct svg-baker-runtime link

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ export default sprite; // don't forget to export!
 ```
 
 It's highly recommended to extend default sprite classes:
-- [for browser-specific env](https://github.com/JetBrains/svg-baker/blob/master/packages/svg-baker-runtime/src/browser-sprite.js)
-- [for isomorphic env](https://github.com/JetBrains/svg-baker/blob/master/packages/svg-baker-runtime/src/sprite.js)
+- [for browser-specific env](https://github.com/JetBrains/svg-mixer/blob/v1/packages/svg-baker-runtime/src/browser-sprite.js)
+- [for isomorphic env](https://github.com/JetBrains/svg-mixer/blob/v1/packages/svg-baker-runtime/src/sprite.js)
 
 <a id="symbol-module"></a>
 ### `symbolModule` (autoconfigured)


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

svg-baker-runtime link 404

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
